### PR TITLE
autocompleteAlwaysOpenOnFocus

### DIFF
--- a/vue-tags-input/vue-tags-input.js
+++ b/vue-tags-input/vue-tags-input.js
@@ -26,6 +26,8 @@ export default {
     // Property which calculates if the autocomplete should be opened or not
     autocompleteOpen() {
       if (this.autocompleteAlwaysOpen) return true;
+      if (this.autocompleteAlwaysOpenOnFocus && this.focused) return true;
+      
       return this.newTag !== null
         && this.newTag.length >= this.autocompleteMinLength
         && this.filteredAutocompleteItems.length > 0

--- a/vue-tags-input/vue-tags-input.props.js
+++ b/vue-tags-input/vue-tags-input.props.js
@@ -124,6 +124,17 @@ export default {
     default: false,
   },
   /**
+   * @description If it's true, the autocomplete layer is always shown when the input is being focused, regardless if
+     an input or an autocomplete items exists.
+   * @property {props}
+   * @type {Boolean}
+   * @default false
+   */
+  autocompleteAlwaysOpenOnFocus: {
+    type: Boolean,
+    default: false,
+  },
+  /**
    * @description Property to disable vue-tags-input.
    * @property {props}
    * @type {Boolean}


### PR DESCRIPTION
Add an option to show always show the autocomplete layer when the input is being on focused.

It's just a suggestion, what do you think?

**EDIT:** I tried to replicate this by hooking into the `focus`, `blur` and `tags-changed` events and updating the `autocomplete-always-open` prop but couldn't make it work (and it was looking messy).