### PR TITLE
Support event.key string for addOnKey prop

### DIFF
--- a/vue-tags-input/vue-tags-input.js
+++ b/vue-tags-input/vue-tags-input.js
@@ -192,7 +192,8 @@ export default {
     },
     // Decides wether the input keyCode is one, which is allowed to modify/add tags
     noTriggerKey(event, category) {
-      const triggerKey = this[category].indexOf(event.keyCode) !== -1;
+      const triggerKey = this[category].indexOf(event.keyCode) !== -1
+        || this[category].indexOf(event.key) !== -1;
       if (triggerKey) event.preventDefault();
       return !triggerKey;
     },

--- a/vue-tags-input/vue-tags-input.props.js
+++ b/vue-tags-input/vue-tags-input.props.js
@@ -13,6 +13,23 @@ const propValidatorTag = value => {
   });
 };
 
+const propValidatorStringNumeric = value => {
+  return !value.some(v => {
+    if (typeof v === 'number') {
+      const numeric = isFinite(v) && Math.floor(v) === v;
+      if (!numeric) console.warn('Only numerics are allowed for this prop. Found:', v);
+      return !numeric;
+    } else if (typeof v === 'string') {
+      const string = /[a-zA-Z]+/.test(v);
+      if (!string) console.warn('Only alpha strings are allowed for this prop. Found:', v);
+      return !string;
+    } else {
+      console.warn('Only numeric and string values are allowed. Found:', v);
+      return false;
+    }
+  });
+};
+
 const propValidatorNumeric = value => {
   return !value.some(v => {
     const numeric = typeof v === 'number' && isFinite(v) && Math.floor(v) === v;
@@ -145,7 +162,8 @@ export default {
   },
   /**
    * @description Custom trigger key codes can be registrated. If the user presses one of these,
-     a tag will be generated out of the input value.
+     a tag will be generated out of the input value. Can be either a numeric keyCode or the key
+     as a string ([13, ':', ';']).
    * @property {props}
    * @type {Array}
    * @default [13]
@@ -153,7 +171,7 @@ export default {
   addOnKey: {
     type: Array,
     default: () => [13],
-    validator: propValidatorNumeric,
+    validator: propValidatorStringNumeric,
   },
   /**
    * @description Custom trigger key codes can be registrated. If the user edits a tag

--- a/vue-tags-input/vue-tags-input.props.js
+++ b/vue-tags-input/vue-tags-input.props.js
@@ -20,7 +20,13 @@ const propValidatorStringNumeric = value => {
       if (!numeric) console.warn('Only numerics are allowed for this prop. Found:', v);
       return !numeric;
     } else if (typeof v === 'string') {
-      const string = /[a-zA-Z]+/.test(v);
+      /**
+       * Regex: || Not totally fool-proof yet, still matches "0a" and such
+       * - allow non-word characters (aka symbols e.g. ;, :, ' etc)
+       * - allow alpha characters
+       * - deny numbers
+       */
+      const string = /\W|[a-z]|!\d/i.test(v);
       if (!string) console.warn('Only alpha strings are allowed for this prop. Found:', v);
       return !string;
     } else {


### PR DESCRIPTION
I have extended the addOnKey prop to also support keypresses based on event.key string as well.

## Use case
- Add new tags when pressing semicolon (;)
- Be able to use colons (:) inside tags

Both semicolon and colon map to the same keyCode: 186. When just using the keyCode, it is impossible to write colons inside tag text if addOnKey has semicolon added.

This change is backwards compatible as it will still continue to support keyCodes as numbers.

Example: `:addOnKey="[13, 188, ';', 9, 32]"`