### PR TITLE
Include preset-env in babel config

### DIFF
--- a/build/lib.config.js
+++ b/build/lib.config.js
@@ -31,6 +31,7 @@ module.exports = {
           loader: 'babel-loader',
           options: {
             plugins: ['@babel/plugin-proposal-object-rest-spread'],
+            presets: ['@babel/preset-env']
           },
         },
       },


### PR DESCRIPTION
This project has `@babel/preset-env` in its devDeps but I can't find any config where babel is being told to actually use `@babel/preset-env`.

## Changes

- Added a bit of config to `build/lib.config.js` so babel uses `@babel/preset-env`

I ran a build before this change and after. The before dist file has arrow funcs and the after dist file does not. I think this fixes issue #71 