### PR TITLE
Documentation issue. Resolves #78

### DIFF
--- a/docs/pages/examples/autocomplete/example1.demo.html
+++ b/docs/pages/examples/autocomplete/example1.demo.html
@@ -34,9 +34,11 @@ export default {
     };
   },
   computed: {
-    return this.autocompleteItems.filter(i => {
-      return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
-    });
+    filteredItems() {
+      return this.autocompleteItems.filter(i => {
+        return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
+      });
+    },
   },
 };
 </script>


### PR DESCRIPTION
There is a small typo in the autocomplete documentation. The line where the computer property was actually named seems to have been omitted by mistake, but has been included in this PR.