### PR TITLE
Document how to show the autocomplete layer on focus

### DIFF
--- a/vue-tags-input/vue-tags-input.props.js
+++ b/vue-tags-input/vue-tags-input.props.js
@@ -118,7 +118,8 @@ export default {
   },
   /**
    * @description The minimum character length which is required
-     until the autocomplete layer is shown.
+     until the autocomplete layer is shown. If set to 0,
+     then it'll be shown on focus.
    * @property {props}
    * @type {Number}
    * @default 1


### PR DESCRIPTION
Talked about this exactly a year ago: https://github.com/JohMun/vue-tags-input/pull/14
Hope it helps :)