### PR TITLE
rm tag-input blur cancel edit handler

### DIFF
--- a/vue-tags-input/tag-input.vue
+++ b/vue-tags-input/tag-input.vue
@@ -9,7 +9,6 @@
     class="ti-tag-input"
     size="1"
     @input="scope.validateTag(scope.index, $event)"
-    @blur="scope.performCancelEdit(scope.index)"
     @keydown="scope.performSaveEdit(scope.index, $event)"
   >
 </template>


### PR DESCRIPTION
There is a problem when I save edits using a button click.
The tag input blur event got fires before the click which cancel the
editing.
Since there is `toggleEditMode` when `saveTag`.
Don't think this `cancelEdit` on blur is necessary.
